### PR TITLE
Fixed lipsync conversion for differing frame count

### DIFF
--- a/LibForge/LibForge/Lipsync/LipsyncConverter.cs
+++ b/LibForge/LibForge/Lipsync/LipsyncConverter.cs
@@ -81,12 +81,14 @@ namespace LibForge.Lipsync
         return data;
       }
 
+      // Calculates max interlaced frames
       int max = lips.Count;
       while (max > 0)
       {
-        if (lips[max - 1]
-          .Frames[fo]
-          .Events.Count > 0)
+        if (fo < lips[max - 1].Frames.Length
+          && lips[max - 1]
+            .Frames[fo]
+            .Events.Count > 0)
           break;
 
         max--;


### PR DESCRIPTION
Added frame length check when calculating max interlaced frames during lipsync conversion. #20